### PR TITLE
Feature/signal aware vm abort

### DIFF
--- a/_vm.go
+++ b/_vm.go
@@ -33,6 +33,7 @@ func mainLoop(L *LState, baseframe *callFrame) {
 func mainLoopWithContext(L *LState, baseframe *callFrame) {
 	var inst uint32
 	var cf *callFrame
+	instrCounter := 0
 
 	if L.stack.IsEmpty() {
 		return
@@ -48,6 +49,14 @@ func mainLoopWithContext(L *LState, baseframe *callFrame) {
 		cf = L.currentFrame
 		inst = cf.Fn.Proto.Code[cf.Pc]
 		cf.Pc++
+
+		// Check abort flag
+		instrCounter++
+		if instrCounter%100 == 0 && ShouldAbort() {
+			L.RaiseError("execution interrupted (abort flag set)")
+			return
+		}
+
 		select {
 		case <-L.ctx.Done():
 			L.RaiseError(L.ctx.Err().Error())

--- a/interrupt.go
+++ b/interrupt.go
@@ -2,16 +2,26 @@ package lua
 
 import "sync/atomic"
 
+// abortFlag holds the global abort signal state.
+// It should be accessed via SetAbort, ResetAbort, and ShouldAbort.
 var abortFlag atomic.Bool
 
+// SetAbort sets the abort flag to true.
+// This is typically called from an external signal handler
+// to cooperatively interrupt Lua execution.
 func SetAbort() {
 	abortFlag.Store(true)
 }
 
+// ResetAbort clears the abort flag.
+// This should be called before starting a new Lua execution,
+// to ensure the abort state is clean.
 func ResetAbort() {
 	abortFlag.Store(false)
 }
 
+// ShouldAbort returns true if an abort has been requested.
+// This is intended to be checked periodically within the VM loop.
 func ShouldAbort() bool {
 	return abortFlag.Load()
 }

--- a/interrupt.go
+++ b/interrupt.go
@@ -1,0 +1,17 @@
+package lua
+
+import "sync/atomic"
+
+var abortFlag atomic.Bool
+
+func SetAbort() {
+	abortFlag.Store(true)
+}
+
+func ResetAbort() {
+	abortFlag.Store(false)
+}
+
+func ShouldAbort() bool {
+	return abortFlag.Load()
+}


### PR DESCRIPTION
Add abort mechanism for signal-safe Lua interruption
    
    Introduced a cooperative interrupt flag (abortFlag) for Lua VM to support reliable
    signal-based termination (e.g., SIGINT).
    
    - Added interrupt.go with atomic abortFlag and helper functions:
      - SetAbort()
      - ResetAbort()
      - ShouldAbort()
    
    - Updated mainLoopWithContext() to check abortFlag every 100 instructions
      to ensure interruptibility even when Go scheduler is blocked (e.g., in tight Lua loops).
    
    This allows external signal handlers to set the flag via SetAbort(),
    bypassing limitations of context.Context cancellation in non-preemptable bytecode execution.